### PR TITLE
Display default text in yield when no ID matches

### DIFF
--- a/dist/hyper-content-for.js
+++ b/dist/hyper-content-for.js
@@ -32,6 +32,8 @@ module.exports = angular.module('hyperContentFor')
         watchFn = function() { return HYPER_CONTENT_FOR_IDS[scope.to]; };
 
         scope.$watch(watchFn, function(newValue) {
+          if (!newValue) return;
+
           elem.empty();
           elem.append(newValue);
         });

--- a/spec/directives/hyper-yield.spec.js
+++ b/spec/directives/hyper-yield.spec.js
@@ -21,4 +21,14 @@ describe('hyper-yield tag', function() {
 
     expect(yieldElement.html()).toContain('<h2>Sub-header in yield</h2>');
   });
+
+  it('transcludes the content if the from value is not present in HYPER_CONTENT_FOR_IDS', function() {
+    delete HYPER_CONTENT_FOR_IDS['header'];;
+
+    var yieldElement = $compile('<hyper-yield to="header"><h2>Sample content</h2></hyper-yield>')($rootScope);
+
+    $rootScope.$digest();
+
+    expect(yieldElement.html()).toContain('<h2>Sample content</h2>');
+  });
 });

--- a/src/directives/hyper-yield.js
+++ b/src/directives/hyper-yield.js
@@ -12,6 +12,8 @@ module.exports = angular.module('hyperContentFor')
         watchFn = function() { return HYPER_CONTENT_FOR_IDS[scope.to]; };
 
         scope.$watch(watchFn, function(newValue) {
+          if (!newValue) return;
+
           elem.empty();
           elem.append(newValue);
         });


### PR DESCRIPTION
Fixes #15. However, there is one thing I'd like to discuss before having this merged. On page load, the content inside of `<hyper-yield>` would be displayed before the watch function triggers and replaces the content, causing a flicker – much like interpolated content would before Angular loads (i.e. without `ng-cloak`). We could probably solve this with a timeout or something down that line, but I prefer not going down that road. If anyone's got a good solution for this, I'm all ears (and eyes)! :smiley: 
