### PR TITLE
Whitelist files that are released on npm and Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,9 @@
   "homepage": "https://github.com/hyperoslo/hyper-content-for-angular",
   "ignore": [
     "**/*",
-    "!dist/**/*"
+    "!dist/**/*",
+    "!LICENSE.md",
+    "!README.md"
   ],
   "dependencies": {
     "angular": "~1.3"

--- a/bower.json
+++ b/bower.json
@@ -16,12 +16,8 @@
   "license": "MIT",
   "homepage": "https://github.com/hyperoslo/hyper-content-for-angular",
   "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "spec",
-    "tests"
+    "**/*",
+    "!dist/**/*"
   ],
   "dependencies": {
     "angular": "~1.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hyper-content-for",
   "version": "1.0.0",
   "description": "Allows you to store HTML for use (and re-use) later.",
-  "files": [ "dist/" ],
+  "files": [ "dist/", "LICENSE.md", "README.md" ],
   "main": "dist/hyper-content-for.js",
   "scripts": {
     "prepublish": "node_modules/browserify/bin/cmd.js index.js -o dist/hyper-content-for.js",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Allows you to store HTML for use (and re-use) later.",
   "main": "hyper-content-for.js",
+  "files": [ "dist/" ],
   "scripts": {
     "prepublish": "node_modules/browserify/bin/cmd.js src/hyper-content-for.js -o dist/hyper-content-for.js",
     "test": "node_modules/karma/bin/karma start --single-run --browsers PhantomJS"


### PR DESCRIPTION
Fixes #30.

As far as I know, there is no standard way of whitelisting in Bower, you'd have to blacklist everything and then negate that for the items you want to include. So I did that. npm has a whitelisting feature. So I used that too.
