### PR TITLE
Fix main file reference for npm and Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "authors": [
     "Sindre Moen <sindrenm@gmail.com>"
   ],
-  "main": "hyper-content-for.js",
+  "main": "dist/hyper-content-for.js",
   "keywords": [
     "hyper",
     "angular",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hyper-content-for",
   "version": "1.0.0",
   "description": "Allows you to store HTML for use (and re-use) later.",
-  "main": "hyper-content-for.js",
+  "main": "dist/hyper-content-for.js",
   "scripts": {
     "prepublish": "node_modules/browserify/bin/cmd.js src/hyper-content-for.js -o dist/hyper-content-for.js",
     "test": "node_modules/karma/bin/karma start --single-run --browsers PhantomJS"


### PR DESCRIPTION
The bower.json and package.json manifests were referencing _./hyper-content-for.js_, but that file is actually located in _./dist/_.
